### PR TITLE
Use dub stdx-allocator package to avoid future breakages

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,5 +6,8 @@
     "description": "A test allocator",
     "copyright": "Copyright © 2016, Atila Neves",
     "license": "BSD",
-    "targetType": "sourceLibrary"
+    "targetType": "sourceLibrary",
+    "dependencies": {
+        "stdx-allocator": "~>2.77.0"
+    }
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"stdx-allocator": "2.77.1"
+	}
+}


### PR DESCRIPTION
This fixes the issues uncovered by this [PR](https://github.com/atilaneves/automem/pull/19)

The `stdx-allocator` package provides a stable snapshot of the allocators module which is currently under work.

@atilaneves